### PR TITLE
Improve compliance to the WSGI spec.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ tests_require = [
     'zope.testing',
     'zope.i18n',
     'zope.component',
+    'Paste',
     ]
 
 

--- a/src/zope/server/http/httptask.py
+++ b/src/zope/server/http/httptask.py
@@ -194,12 +194,10 @@ class HTTPTask(object):
         env['SERVER_NAME'] = server.server_name
         env['SERVER_SOFTWARE'] = server.SERVER_IDENT
         env['SERVER_PROTOCOL'] = "HTTP/%s" % self.version
-        env['CHANNEL_CREATION_TIME'] = channel.creation_time
-        env['SCRIPT_NAME']=''
-        env['PATH_INFO']='/' + path
-        query = request_data.query
-        if query:
-            env['QUERY_STRING'] = query
+        env['CHANNEL_CREATION_TIME'] = str(channel.creation_time)
+        env['SCRIPT_NAME']= ''
+        env['PATH_INFO']= '/' + path
+        env['QUERY_STRING'] = request_data.query or ''
         env['GATEWAY_INTERFACE'] = 'CGI/1.1'
         addr = channel.addr[0]
         env['REMOTE_ADDR'] = addr


### PR DESCRIPTION
When trying to use the paste.lint middleware in development, I ran into a few issues
with zope.server's adherence to WSGI.

This PR makes the following changes:
- Call close method if present on iterables returned by start_response.
- Don't include non-string values in the CGI environment (CHANNEL_CREATION_TIME).
- Always include QUERY_STRING to avoid the cgi module falling back to
  sys.argv.
- Add tests based on paste.lint middleware.
