### PR TITLE
Implement OverflowableBuffer in terms of SpooledTemporaryFile

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,10 @@
   ``"None"`` when the first request line cannot be parsed. Now they
   are empty strings.
 
+- Reimplement ``buffers.OverflowableBuffer`` in terms of the standard
+  libraries ``tempfile.SpooledTemporaryFile``. This is much simpler.
+  See `issue 5 <https://github.com/zopefoundation/zope.server/issues/5>`_.
+
 - Achieve and maintain 100% test coverage.
 
 3.9.0 (2013-03-13)

--- a/src/zope/server/tests/test_buffers.py
+++ b/src/zope/server/tests/test_buffers.py
@@ -43,6 +43,14 @@ class TestStringBuffer(unittest.TestCase):
         self.assertEqual(b'data', data)
         self.assertEqual(4, buf.remain)
 
+    def test_construct_from_buffer(self):
+        buf1 = self._makeOne()
+        buf1.append(b'data')
+
+        buf2 = self._getFUT()(buf1)
+
+        self.assertEqual(buf2.get(), b'data')
+
 class TestTempfileBasedBuffer(TestStringBuffer):
 
     def _getFUT(self):


### PR DESCRIPTION
Fixes #5

Even for small buffers (the 8192 that previously were guaranteed to be kept in a simple string) this should be faster, depending on the number of writes possibly. Previously the strbuf was built up with
concatenation: `buf = buf + data`. Now we go directly into BytesIO and avoid the extra copying.

Microbenchmarks on Python 3.6:
```pycon
In [1]: def append():
   ...:     buf = b''
   ...:     while len(buf) < 8192:
   ...:         buf += b'data' * 100
   ...:

In [4]: %timeit append()
10.9 µs ± 268 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)

In [8]: def bio():
   ...:     b = io.BytesIO()
   ...:     cnt = 0
   ...:     while cnt < 8192:
   ...:         cnt += b.write(b'data'*100)
   ...:

In [9]: bio()

In [10]: %timeit bio()
8.55 µs ± 282 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)
```

So more than 2µs faster at least for writing.

Now, there were a handful of `no cover` directives below, indicating code that was untested, so I can't be 100% sure that the semantics are exactly equivalent. However, if the other implementations of buffers are doing what they are supposed to do (and they *are* fully tested) it should be ok.