### PR TITLE
Fix failing test_wsgi_compliance on Python 3

### DIFF
--- a/src/zope/server/http/tests/test_wsgiserver.py
+++ b/src/zope/server/http/tests/test_wsgiserver.py
@@ -202,8 +202,6 @@ class Tests(LoopTestMixin,
             h.putheader('Accept', 'text/plain')
             h.endheaders()
             response = h.getresponse()
-            if return_response:
-                return response
             length = int(response.getheader('Content-Length', '0'))
             if length:
                 response_body = response.read(length)
@@ -212,7 +210,10 @@ class Tests(LoopTestMixin,
 
             self.assertEqual(length, len(response_body))
 
-            return response.status, response_body
+            if return_response:
+                return response, response_body
+            else:
+                return response.status, response_body
 
 
     def testDeeperPath(self):
@@ -252,7 +253,7 @@ class Tests(LoopTestMixin,
         self.assertEqual(status, 409)
 
     def testServerAsProxy(self):
-        response = self.invokeRequest(
+        response, response_body = self.invokeRequest(
             '/proxy', return_response=True)
         # The headers set by the proxy are honored,
         self.assertEqual(
@@ -263,7 +264,7 @@ class Tests(LoopTestMixin,
         self.assertEqual(
             response.getheader('Via'), 'zope.server.http (Browser)')
         # And the content got here too.
-        self.assertEqual(response.read(), b'Proxied Content')
+        self.assertEqual(response_body, b'Proxied Content')
 
     def testWSGIVariables(self):
         # Assert that the environment contains all required WSGI variables

--- a/src/zope/server/tests/test_serverbase.py
+++ b/src/zope/server/tests/test_serverbase.py
@@ -41,6 +41,7 @@ class FakeSocket(object):
 class NonBindingServerBase(serverbase.ServerBase):
 
     def bind(self, addr):
+        self.socket.close()
         self.socket = FakeSocket()
 
     logs = ()

--- a/tox.ini
+++ b/tox.ini
@@ -8,8 +8,7 @@ envlist =
     coverage
 
 [testenv]
-deps =
-    .[test]
+extras = test
 commands =
     zope-testrunner --test-path=src {posargs:-pvc}
 
@@ -17,7 +16,6 @@ commands =
 usedevelop = true
 basepython = python3.6
 deps =
-    {[testenv]deps}
     coverage
 commands =
     coverage run -m zope.testrunner --test-path=src {posargs:-pvc}


### PR DESCRIPTION
The list of warnings had one ResourceWarning about an unclosed socket
object.

Fixes #11.