### PR TITLE
Fix many (but not all) warnings

### DIFF
--- a/src/zope/server/buffers.py
+++ b/src/zope/server/buffers.py
@@ -98,10 +98,14 @@ class FileBasedBuffer(object):
             if not data:
                 break
             nf.write(data)
+        self.file.close()
         self.file = nf
 
     def getfile(self):
         return self.file
+
+    def close(self):
+        self.file.close()
 
 
 class TempfileBasedBuffer(FileBasedBuffer):

--- a/src/zope/server/ftp/tests/test_ftpserver.py
+++ b/src/zope/server/ftp/tests/test_ftpserver.py
@@ -42,6 +42,11 @@ class TestIntegration(LoopTestMixin,
                       AsyncoreErrorHookMixin,
                       unittest.TestCase):
 
+    # Avoid DeprecationWarning for assertRaisesRegexp on Python 3 while
+    # coping with Python 2 not having the Regex spelling variant
+    assertRaisesRegex = getattr(unittest.TestCase, 'assertRaisesRegex',
+                                unittest.TestCase.assertRaisesRegexp)
+
     task_dispatcher_count = 1
 
     def setUp(self):
@@ -360,7 +365,7 @@ class TestIntegration(LoopTestMixin,
 
     def testMODE(self):
         conn = self.getFTPConnection()
-        with self.assertRaisesRegexp(ftplib.Error, 'MODE_UNKNOWN'):
+        with self.assertRaisesRegex(ftplib.Error, 'MODE_UNKNOWN'):
             conn.sendcmd('MODE a b')
 
         conn.sendcmd('MODE s')
@@ -377,11 +382,11 @@ class TestIntegration(LoopTestMixin,
 
     def testRETR_not_understood(self):
         conn = self.getFTPConnection()
-        with self.assertRaisesRegexp(ftplib.Error, "command not understood"):
+        with self.assertRaisesRegex(ftplib.Error, "command not understood"):
             conn.sendcmd('RETR')
     def testRETR_no_file(self):
         conn = self.getFTPConnection()
-        with self.assertRaisesRegexp(ftplib.Error, "not a file"):
+        with self.assertRaisesRegex(ftplib.Error, "not a file"):
             conn.sendcmd('RETR /DNE')
 
     def testRETR(self):
@@ -411,33 +416,33 @@ class TestIntegration(LoopTestMixin,
 
     def testREST(self):
         conn = self.getFTPConnection()
-        with self.assertRaisesRegexp(ftplib.Error, 'arguments'):
+        with self.assertRaisesRegex(ftplib.Error, 'arguments'):
             conn.sendcmd("REST a")
 
     def testRMD(self):
         conn = self.getFTPConnection()
-        with self.assertRaisesRegexp(ftplib.Error, 'arguments'):
+        with self.assertRaisesRegex(ftplib.Error, 'arguments'):
             conn.sendcmd('RMD')
 
-        with self.assertRaisesRegexp(ftplib.Error, 'denied'):
+        with self.assertRaisesRegex(ftplib.Error, 'denied'):
             conn.sendcmd('RMD /foo')
 
     def testRNFR_dne(self):
         conn = self.getFTPConnection()
-        with self.assertRaisesRegexp(ftplib.Error, 'No such file'):
+        with self.assertRaisesRegex(ftplib.Error, 'No such file'):
             conn.sendcmd('RNFR /dne')
 
     def testRNTO_bad_state(self):
         conn = self.getFTPConnection()
 
-        with self.assertRaisesRegexp(ftplib.Error, 'ERR_RENAME'):
+        with self.assertRaisesRegex(ftplib.Error, 'ERR_RENAME'):
             conn.sendcmd('RNTO /dne')
 
     def testRNFR(self):
         conn = self.getFTPConnection()
 
         conn.sendcmd('RNFR /existing')
-        with self.assertRaisesRegexp(ftplib.Error, 'denied'):
+        with self.assertRaisesRegex(ftplib.Error, 'denied'):
             conn.sendcmd('RNTO /existing2')
 
     def testSIZE(self):
@@ -447,7 +452,7 @@ class TestIntegration(LoopTestMixin,
         # as an int
         self.assertEqual(resp, '213 17 Bytes')
 
-        with self.assertRaisesRegexp(ftplib.Error, 'No such file'):
+        with self.assertRaisesRegex(ftplib.Error, 'No such file'):
             conn.size('/DNE')
 
     @unittest.expectedFailure
@@ -457,7 +462,7 @@ class TestIntegration(LoopTestMixin,
 
     def testSTRU(self):
         conn = self.getFTPConnection()
-        with self.assertRaisesRegexp(ftplib.Error, 'Unimplemented'):
+        with self.assertRaisesRegex(ftplib.Error, 'Unimplemented'):
             conn.sendcmd('STRU a b')
 
         conn.sendcmd('STRU f')
@@ -469,10 +474,10 @@ class TestIntegration(LoopTestMixin,
 
     def testTYPE(self):
         conn = self.getFTPConnection()
-        with self.assertRaisesRegexp(ftplib.Error, 'arguments'):
+        with self.assertRaisesRegex(ftplib.Error, 'arguments'):
             conn.sendcmd('TYPE g')
 
-        with self.assertRaisesRegexp(ftplib.Error, 'size must be 8'):
+        with self.assertRaisesRegex(ftplib.Error, 'size must be 8'):
             conn.sendcmd('TYPE l 9 x')
 
 class MockChannel(object):

--- a/src/zope/server/ftp/tests/test_publisher.py
+++ b/src/zope/server/ftp/tests/test_publisher.py
@@ -128,6 +128,7 @@ class TestPublisherFTPServer(unittest.TestCase):
                 return
 
         server = NonBinding(Request, 'name', None, 80, start=False)
+        self.addCleanup(server.close)
         self.assertIsNotNone(server.fs_access)
 
 class TestPublisherFileSystemAccess(unittest.TestCase):

--- a/src/zope/server/http/tests/test_wsgiserver.py
+++ b/src/zope/server/http/tests/test_wsgiserver.py
@@ -567,6 +567,8 @@ class TestPaste(unittest.TestCase):
         class Server(object):
             def __init__(self, *args, **kwargs):
                 pass
+            def close(self):
+                pass
 
         class asyncore(object):
             looped = False

--- a/src/zope/server/http/wsgihttpserver.py
+++ b/src/zope/server/http/wsgihttpserver.py
@@ -16,10 +16,12 @@
 import asyncore
 import re
 import sys
+from contextlib import closing
+
 import six
+import zope.security.management
 from zope.server.http.httpserver import HTTPServer
 from zope.server.taskthreads import ThreadedTaskDispatcher
-import zope.security.management
 
 
 def fakeWrite(body):
@@ -163,6 +165,6 @@ def run_paste(wsgi_app, global_conf, name='zope.server.http',
 
     task_dispatcher = ThreadedTaskDispatcher()
     task_dispatcher.setThreadCount(threads)
-    server = WSGIHTTPServer(wsgi_app, name, host, port,
-                            task_dispatcher=task_dispatcher)
-    asyncore.loop()
+    with closing(WSGIHTTPServer(wsgi_app, name, host, port,
+                                task_dispatcher=task_dispatcher)):
+        asyncore.loop()

--- a/src/zope/server/serverbase.py
+++ b/src/zope/server/serverbase.py
@@ -41,13 +41,13 @@ class ServerBase(asyncore.dispatcher, object):
         asyncore.dispatcher.__init__(self)
         self.port = port
         self.task_dispatcher = task_dispatcher
+        self.verbose = verbose
+        self.hit_log = hit_log
+        self.logger = logging.getLogger(self.__class__.__name__)
         self.create_socket(socket.AF_INET, socket.SOCK_STREAM)
         try:
             self.set_reuse_addr()
             self.bind((ip, port))
-            self.verbose = verbose
-            self.hit_log = hit_log
-            self.logger = logging.getLogger(self.__class__.__name__)
             self.server_name = self.computeServerName(ip)
 
             if start:

--- a/src/zope/server/serverbase.py
+++ b/src/zope/server/serverbase.py
@@ -42,15 +42,19 @@ class ServerBase(asyncore.dispatcher, object):
         self.port = port
         self.task_dispatcher = task_dispatcher
         self.create_socket(socket.AF_INET, socket.SOCK_STREAM)
-        self.set_reuse_addr()
-        self.bind((ip, port))
-        self.verbose = verbose
-        self.hit_log = hit_log
-        self.logger = logging.getLogger(self.__class__.__name__)
-        self.server_name = self.computeServerName(ip)
+        try:
+            self.set_reuse_addr()
+            self.bind((ip, port))
+            self.verbose = verbose
+            self.hit_log = hit_log
+            self.logger = logging.getLogger(self.__class__.__name__)
+            self.server_name = self.computeServerName(ip)
 
-        if start:
-            self.accept_connections()
+            if start:
+                self.accept_connections()
+        except BaseException:
+            self.close()
+            raise
 
     level_mapping = {
         'info': logging.INFO,

--- a/src/zope/server/tests/__init__.py
+++ b/src/zope/server/tests/__init__.py
@@ -22,11 +22,13 @@ class LoopTestMixin(object):
         super(LoopTestMixin, self).setUp()
         td = self.td = ThreadedTaskDispatcher()
         td.setThreadCount(self.task_dispatcher_count)
-        if len(asyncore.socket_map) != 1:
+        if len(asyncore.socket_map) != 1:  # pragma: no cover
             # Let sockets die off.
-            # TODO tests should be more careful to clear the socket map.
+            # (tests should be more careful to clear the socket map, and they
+            # currently do, but let's keep this backstop just in case, to avoid
+            # confusing failures).
             gc.collect()
-            asyncore.poll(0.1) # pragma: no cover
+            asyncore.poll(0.1)
         self.orig_map_size = len(asyncore.socket_map)
 
         self.server = self._makeServer()

--- a/src/zope/server/tests/test_buffers.py
+++ b/src/zope/server/tests/test_buffers.py
@@ -14,7 +14,9 @@ class TestStringBuffer(unittest.TestCase):
         return buffers.StringIOBasedBuffer
 
     def _makeOne(self):
-        return self._getFUT()()
+        buf = self._getFUT()()
+        self.addCleanup(buf.close)
+        return buf
 
     def test_cannot_skip_empty(self):
         with self.assertRaises(ValueError):
@@ -48,6 +50,7 @@ class TestStringBuffer(unittest.TestCase):
         buf1.append(b'data')
 
         buf2 = self._getFUT()(buf1)
+        self.addCleanup(buf2.close)
 
         self.assertEqual(buf2.get(), b'data')
 

--- a/src/zope/server/trigger.py
+++ b/src/zope/server/trigger.py
@@ -215,6 +215,8 @@ class sockettrigger(_triggerbase, asyncore.dispatcher):
                     # I've seen on two WinXP Pro SP2 boxes, under
                     # Pythons 2.3.5 and 2.4.1.
                     # (Original commit: https://github.com/zopefoundation/ZEO/commit/c4f736a78ca6713fc3dec21f8aa1fa6f144dd82f)
+                    a.close()
+                    w.close()
                     raise
                 # (10048, 'Address already in use')
                 # assert count <= 2 # never triggered in Tim's tests

--- a/src/zope/server/trigger.py
+++ b/src/zope/server/trigger.py
@@ -141,7 +141,7 @@ if hasattr(asyncore, 'file_dispatcher'):
 
         def __init__(self):
             _triggerbase.__init__(self)
-            r, self.trigger = self._fds = os.pipe()
+            r, self.trigger = os.pipe()
             asyncore.file_dispatcher.__init__(self, r)
 
             if self.socket.fd != r:
@@ -154,12 +154,13 @@ if hasattr(asyncore, 'file_dispatcher'):
                 os.close(r)
 
         def _close(self):
-            for fd in self._fds:
-                try:
-                    os.close(fd)
-                except OSError:
-                    pass
-            self._fds = []
+            # NB: this causes self.del_channel() to be called twice, but it's
+            # idempotent, so it's fine.
+            asyncore.file_dispatcher.close(self)
+            try:
+                os.close(self.trigger)
+            except OSError:
+                pass
 
         def _physical_pull(self):
             os.write(self.trigger, b'x')
@@ -215,6 +216,8 @@ class sockettrigger(_triggerbase, asyncore.dispatcher):
                     # I've seen on two WinXP Pro SP2 boxes, under
                     # Pythons 2.3.5 and 2.4.1.
                     # (Original commit: https://github.com/zopefoundation/ZEO/commit/c4f736a78ca6713fc3dec21f8aa1fa6f144dd82f)
+                    a.close()
+                    w.close()
                     raise
                 # (10048, 'Address already in use')
                 # assert count <= 2 # never triggered in Tim's tests


### PR DESCRIPTION
I've been trying to eliminate all warnings shown during the test run.  This PR fixes many (but not all).

Protip: `.tox/py37/bin/python -Wd -X tracemalloc=10 -m zope.testrunner --test-path=src -pvc` is very helpful, especially if you first do `tox --develop -e py37` so that the tests run your latest edits.