### PR TITLE
Fix pipetrigger.close() to close the right file descriptors

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,8 @@
 4.0.2 (unreleased)
 ==================
 
-- Nothing changed yet.
+- Fix pipetrigger.close() to close the right file descriptor.
+  (This could've been causing EBADF errors in unrelated places!)
 
 
 4.0.1 (2017-10-31)

--- a/src/zope/server/tests/test_trigger.py
+++ b/src/zope/server/tests/test_trigger.py
@@ -63,7 +63,7 @@ class TestPipeTrigger(unittest.TestCase):
         def thunk():
             raise Exception("TestException")
         t = self._makeOne()
-        t.close()
+        t.recv = lambda s: ''
         t.thunks.append(thunk)
         trigger.print = buf.write
         try:

--- a/src/zope/server/trigger.py
+++ b/src/zope/server/trigger.py
@@ -141,7 +141,7 @@ if hasattr(asyncore, 'file_dispatcher'):
 
         def __init__(self):
             _triggerbase.__init__(self)
-            r, self.trigger = self._fds = os.pipe()
+            r, self.trigger = os.pipe()
             asyncore.file_dispatcher.__init__(self, r)
 
             if self.socket.fd != r:
@@ -154,12 +154,15 @@ if hasattr(asyncore, 'file_dispatcher'):
                 os.close(r)
 
         def _close(self):
-            for fd in self._fds:
+            if self.socket is not None:
+                self.socket.close()
+                self.socket = None
+            if self.trigger is not None:
                 try:
-                    os.close(fd)
+                    os.close(self.trigger)
                 except OSError:
                     pass
-            self._fds = []
+                self.trigger = None
 
         def _physical_pull(self):
             os.write(self.trigger, b'x')

--- a/src/zope/server/trigger.py
+++ b/src/zope/server/trigger.py
@@ -158,10 +158,7 @@ if hasattr(asyncore, 'file_dispatcher'):
                 self.socket.close()
                 self.socket = None
             if self.trigger is not None:
-                try:
-                    os.close(self.trigger)
-                except OSError:
-                    pass
+                os.close(self.trigger)
                 self.trigger = None
 
         def _physical_pull(self):


### PR DESCRIPTION
Here's what was happening:

- `pipetrigger.__init__()` creates two file descriptors by invoking os.pipe(), let's call them r1 and w1
- `asyncore.file_dispatcher.__init__()` wraps r1 in a `file_wrapper()` that does an `os.dup()`, creating r2
- `pipetrigger.__init__()` closes r1
- `pipetrigger.__init__()` keeps `self._fd = (r1, w1)` despite r1 being closed already!
- `pipetrigger._close()` closes all desciptors from `self._fd`, closing r1 again (causing an OSError for EBADF or closing a random real file the program still wants to use), but doesn't close self.socket, which is the file_wrapper instance holding r2 open.

I also had to fix one test that was calling trigger.close() and expecting trigger.recv() to keep working afterwards.