### PR TITLE
Update PasteDeploy link

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,8 @@
 
 - Add `python_requires` to `setup.py`.
 
+- Update PasteDeploy link in README.
+
 
 4.0.2 (2019-07-11)
 ==================

--- a/README.rst
+++ b/README.rst
@@ -31,4 +31,4 @@ WSGI gateway from a configuration file, e.g.::
   port = 8080
 
 .. _WSGI: http://www.python.org/dev/peps/pep-0333/
-.. _PasteDeploy: http://pythonpaste.org/deploy/
+.. _PasteDeploy: https://docs.pylonsproject.org/projects/pastedeploy/


### PR DESCRIPTION
http://pythonpaste.org/deploy/ now redirects to the Wayback Machine.