### PR TITLE
Avoid traceback reference cycle in _triggerbase.handle_read

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,8 @@
 
 - Update PasteDeploy link in README.
 
+- Avoid traceback reference cycle in ``_triggerbase.handle_read``.
+
 
 4.0.2 (2019-07-11)
 ==================

--- a/src/zope/server/trigger.py
+++ b/src/zope/server/trigger.py
@@ -129,8 +129,11 @@ class _triggerbase(object):
                     thunk()
                 except:  # noqa: E722 do not use bare 'except'
                     _nil, t, v, tbinfo = asyncore.compact_traceback()
-                    print('exception in trigger thunk:'
-                          ' (%s:%s %s)' % (t, v, tbinfo))
+                    try:
+                        print('exception in trigger thunk:'
+                              ' (%s:%s %s)' % (t, v, tbinfo))
+                    finally:
+                        del t, v, tbinfo
             self.thunks = []
 
     def __repr__(self):


### PR DESCRIPTION
``asyncore.compact_traceback()`` called from ``_triggerbase.handle_read`` returns a tuple containing (among other things) the exception value and its traceback, which have references to the ``handle_read`` frame.  Storing those in local variables creates reference cycles.  Clear those variables in a ``finally`` block to avoid this.

Found by code inspection in passing when auditing a codebase for similar reference cycles.