### PR TITLE
Close output buffer when closing a DualModeChannel

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,10 @@
 
 - Avoid traceback reference cycle in ``_triggerbase.handle_read``.
 
+- Close output buffer when closing a ``DualModeChannel`` to fix a
+  ``ResourceWarning``. See `issue 25
+  <https://github.com/zopefoundation/zope.server/issues/25>`_.
+
 
 4.0.2 (2019-07-11)
 ==================

--- a/src/zope/server/dualmodechannel.py
+++ b/src/zope/server/dualmodechannel.py
@@ -206,6 +206,7 @@ class DualModeChannel(asyncore.dispatcher, object):
         # closed in a thread, the main loop can end up with a bad file
         # descriptor.
         assert self.async_mode
+        self.outbuf.close()
         self.connected = False
         try:
             asyncore.dispatcher.close(self)


### PR DESCRIPTION
This fixes a ``ResourceWarning``.

Fixes #25.